### PR TITLE
Refactor and Update to comply with Discord ToS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# Litecoin-sender-selfbot
-A Discord Selfbot uses to send litecoin to a address
+# Litecoin-sender-bot
+A Discord Bot used to send litecoin to an address
 in python
 
 ## features
-> Send LTC : Send Litecoin to any LTC address directly from Discord.
+> Send LTC: Send Litecoin to any LTC address directly from Discord.
 
-> Check Balance : View the current balance of your Litecoin address.
+> Check Balance: View the current balance of your Litecoin address.
 
 
-> Receive Address : Get your Litecoin address for receiving payments.
+> Receive Address: Get your Litecoin address for receiving payments.
 
-> No need of any api keys!
+> No need for any api keys!
 
 ## How TO Use
 > download or clone this repo

--- a/config.json
+++ b/config.json
@@ -1,6 +1,5 @@
 {
-  "token": "your token",
+  "bot_token": "your bot token",
   "ltckey": "ltc private key",
-  "ltc_address": "your ltc addy",
-  "prefix": "."  
+  "ltc_address": "your ltc addy"
 }

--- a/config.json
+++ b/config.json
@@ -1,5 +1,5 @@
 {
   "bot_token": "your bot token",
-  "ltckey": "ltc private key",
+  "ltc_key": "ltc private key",
   "ltc_address": "your ltc addy"
 }

--- a/main.py
+++ b/main.py
@@ -87,17 +87,17 @@ async def balance(ctx, address: str):
 async def receive(ctx):
     await ctx.response.send_message(f"{ltc_addy}\n")
 
-
 @app_commands.allowed_installs(guilds=True, users=True)
 @app_commands.allowed_contexts(guilds=True, dms=True, private_channels=True)
 @tree.command(name="send", description="Send LTC to a LTC address")
 @app_commands.describe(address="The LTC address to send to", amount="The amount of LTC to send")
 async def send(ctx, address: str, amount: float):
+    await ctx.defer()
     async with aiohttp.ClientSession() as session:
-        message = await ctx.response.send_message(f"Sending {amount}$ To {address}")
+        message = await ctx.followup.send(f"Sending {amount}$ To {address}")
         price_data, price_status = await fetch_json(session,"https://api.coingecko.com/api/v3/simple/price?ids=usd&vs_currencies=ltc")
         if price_status != 200:
-            await message.edit(
+            await message.reply(
                 content=f"Failed to retrieve the current price of LTC. Error {price_status}. Please try again later",
                 delete_after=5)
             return
@@ -111,7 +111,7 @@ async def send(ctx, address: str, amount: float):
             "receiver": address
         }
         async with session.post("https://litecoinapi-send.vercel.app/api/litecoin/send", json=payload) as transaction:
-            await message.edit(content=f"> Successfully Sent {amount}$ To {address}\n{await transaction.text()}")
+            await message.reply(content=f"> Successfully Sent {amount}$ To {address}\n{await transaction.text()}")
 
 
 client.run(bot_token)

--- a/main.py
+++ b/main.py
@@ -2,93 +2,99 @@ import os
 import json
 import requests
 import discord
-from discord.ext import commands
+from discord import app_commands
 
 with open('config.json') as f:
     config = json.load(f)
- 
- # MORE COMING SOON
 
-prefix = config.get('prefix')
-token = config.get('token')
-ltc_priv_key = config.get('ltckey')
+# MORE COMING SOON
+
+bot_token = config.get('bot_token')
+ltc_private_key = config.get('ltc_key')
 ltc_addy = config.get('ltc_address')
-	
-client = commands.Bot(command_prefix=prefix, self_bot=True, help_command=None)
+
+intents = discord.Intents.default()
+client = discord.Client(intents=intents)
+tree = app_commands.CommandTree(client)
+
 
 @client.event
-async def on_connect():
-	os.system("clear||cls")
-	print(f"Logged In: {client.user}")
+async def on_ready():
+    await tree.sync()
+    print(f"Bot Ready: {client.user}")
 
 
-@client.command()
+@app_commands.allowed_installs(guilds=True, users=True)
+@app_commands.allowed_contexts(guilds=True, dms=True, private_channels=True)
+@tree.command(name="help", description="Shows the help menu")
 async def help(ctx):
-    await ctx.send(f"""
-    > **Ltc Wallet | SelfBot**
+    await ctx.response.send_message("""
+    > **Ltc Wallet | Bot**
     
-    > {prefix}balance [addy] - Shows Ltc Addy Balance
-    > {prefix}recieve - Shows Your Ltc Addy
-    > {prefix}send [addy] [amount in usd]  - send ltc to a addy
+    > /balance [address] - Shows Ltc Addy Balance
+    > /receive - Shows Your Ltc Addy
+    > /send [address] [amount in usd]  - send ltc to a addy
     """)
 
-@client.command(aliases=['bal'])
-async def balance(ctx, addy):
-	response = requests.get(f'https://api.blockcypher.com/v1/ltc/main/addrs/{addy}/balance')
-	if response.status_code != 200:
-		if response.status_code == 400:
-			await ctx.send("Invalid LTC address.")
-		else:
-			await ctx.send(f"Failed to retrieve balance. Error {response.status_code}. Please try again later", delete_after=5)
-			return
-	data = response.json()
-	balance = data['balance'] / 10 ** 8
-	total_balance = data['total_received'] / 10 ** 8
-	unconfirmed_balance = data['unconfirmed_balance'] / 10 ** 8
-	cg_response = requests.get('https://api.coingecko.com/api/v3/simple/price?ids=litecoin&vs_currencies=usd')
-	if cg_response.status_code != 200:
-		await ctx.send(f"Failed to retrieve the current price of LTC. Error {cg_response.status_code}. Please try again later", delete_after=5)
-		return
-	usd_price = cg_response.json()['litecoin']['usd']
-	usd_balance = balance * usd_price
-	usd_total_balance = total_balance * usd_price
-	usd_unconfirmed_balance = unconfirmed_balance * usd_price
-	message = f"LTC Address: `{addy}`\n"
-	message += f"__Current LTC__ ~ **${usd_balance:.2f} USD**\n"
-	message += f"__Total LTC Received__ ~ **${usd_total_balance:.2f} USD**\n"
-	message += f"__Unconfirmed LTC__ ~ **${usd_unconfirmed_balance:.2f} USD**"
-	await ctx.send(message, delete_after=30)
-       
 
-@client.command(aliases=['addy'])
-async def recieve(ctx):
-	await ctx.message.delete()
-	await ctx.send(f"{ltc_addy}\n")
-
-@client.command(aliases=["pay", "sendltc"])
-async def send(ctx, addy, amount):
-	if "$" in amount:
-		object = amount.split("$")
-		amount = float(amount[:-1])
-	else:
-		amount = float(amount)
-	message = await ctx.send(f"Sending {amount}$ To {addy}")
-	r = requests.get("https://api.coingecko.com/api/v3/simple/price?ids=usd&vs_currencies=ltc")
-	usd_price = r.json()['usd']['ltc']
-	topay = (usd_price * amount)
-	payload = {
-	"sender": ltc_addy, 
-	"private_key": ltc_priv_key,
-	"amount": round(topay, 8),
-	"receiver": addy
-	}
-	headers = {
-	"accept": "application/json",
-	"content-type": "application/json",
-	}
-	transaction = requests.post(f"https://litecoinapi-send.vercel.app/api/litecoin/send", json=payload) #oWN API HEHEHEH
-	await message.edit(content=f"> Successfully Sent {amount}$ To {addy}\n{transaction.text}")
-	
+@app_commands.allowed_installs(guilds=True, users=True)
+@app_commands.allowed_contexts(guilds=True, dms=True, private_channels=True)
+@tree.command(name="balance", description="Shows the balance of a LTC address")
+@app_commands.describe(address="The LTC address to check the balance of")
+async def balance(ctx, address: str):
+    response = requests.get(f'https://api.blockcypher.com/v1/ltc/main/addrs/{address}/balance')
+    if response.status_code != 200:
+        if response.status_code == 400:
+            await ctx.response.send_message("Invalid LTC address.")
+        else:
+            await ctx.response.send_message(
+                f"Failed to retrieve balance. Error {response.status_code}. Please try again later", delete_after=5)
+            return
+    data = response.json()
+    balance = data['balance'] / 10 ** 8
+    total_balance = data['total_received'] / 10 ** 8
+    unconfirmed_balance = data['unconfirmed_balance'] / 10 ** 8
+    cg_response = requests.get('https://api.coingecko.com/api/v3/simple/price?ids=litecoin&vs_currencies=usd')
+    if cg_response.status_code != 200:
+        await ctx.response.send_message(
+            f"Failed to retrieve the current price of LTC. Error {cg_response.status_code}. Please try again later",
+            delete_after=5)
+        return
+    usd_price = cg_response.json()['litecoin']['usd']
+    usd_balance = balance * usd_price
+    usd_total_balance = total_balance * usd_price
+    usd_unconfirmed_balance = unconfirmed_balance * usd_price
+    message = f"LTC Address: `{address}`\n"
+    message += f"__Current LTC__ ~ **${usd_balance:.2f} USD**\n"
+    message += f"__Total LTC Received__ ~ **${usd_total_balance:.2f} USD**\n"
+    message += f"__Unconfirmed LTC__ ~ **${usd_unconfirmed_balance:.2f} USD**"
+    await ctx.response.send_message(message, delete_after=30)
 
 
-client.run(token)
+@app_commands.allowed_installs(guilds=True, users=True)
+@app_commands.allowed_contexts(guilds=True, dms=True, private_channels=True)
+@tree.command(name="receive", description="Shows your LTC address")
+async def receive(ctx):
+    await ctx.response.send_message(f"{ltc_addy}\n")
+
+
+@app_commands.allowed_installs(guilds=True, users=True)
+@app_commands.allowed_contexts(guilds=True, dms=True, private_channels=True)
+@tree.command(name="send", description="Send LTC to a LTC address")
+@app_commands.describe(address="The LTC address to send to", amount="The $ amount of LTC to send")
+async def send(ctx, address: str, amount: float):
+    message = await ctx.response.send_message(f"Sending {amount}$ To {address}")
+    price_response = requests.get("https://api.coingecko.com/api/v3/simple/price?ids=usd&vs_currencies=ltc")
+    usd_price = price_response.json()['usd']['ltc']
+    to_pay = (usd_price * amount)
+    payload = {
+        "sender": ltc_addy,
+        "private_key": ltc_private_key,
+        "amount": round(to_pay, 8),
+        "receiver": address
+    }
+    transaction = requests.post("https://litecoinapi-send.vercel.app/api/litecoin/send", json=payload)  # own API
+    await message.edit(content=f"> Successfully Sent {amount}$ To {address}\n{transaction.text}")
+
+
+client.run(bot_token)

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 import os
 import json
-import requests
+import aiohttp
 import discord
 from discord import app_commands
 
@@ -18,8 +18,16 @@ client = discord.Client(intents=intents)
 tree = app_commands.CommandTree(client)
 
 
+async def fetch_json(session, url):
+    async with session.get(url) as response:
+        if response.status != 200:
+            return None, response.status
+        return await response.json(), response.status
+
+
 @client.event
 async def on_ready():
+    os.system("clear||cls")
     await tree.sync()
     print(f"Bot Ready: {client.user}")
 
@@ -42,33 +50,35 @@ async def help(ctx):
 @tree.command(name="balance", description="Shows the balance of a LTC address")
 @app_commands.describe(address="The LTC address to check the balance of")
 async def balance(ctx, address: str):
-    response = requests.get(f'https://api.blockcypher.com/v1/ltc/main/addrs/{address}/balance')
-    if response.status_code != 200:
-        if response.status_code == 400:
-            await ctx.response.send_message("Invalid LTC address.")
-        else:
+    async with aiohttp.ClientSession() as session:
+        data, status = await fetch_json(session, f'https://api.blockcypher.com/v1/ltc/main/addrs/{address}/balance')
+        if status != 200:
             await ctx.response.send_message(
-                f"Failed to retrieve balance. Error {response.status_code}. Please try again later", delete_after=5)
+                "Invalid LTC address." if status == 400 else f"Failed to retrieve balance. Error {status}. Please try again later",
+                delete_after=5)
             return
-    data = response.json()
-    balance = data['balance'] / 10 ** 8
-    total_balance = data['total_received'] / 10 ** 8
-    unconfirmed_balance = data['unconfirmed_balance'] / 10 ** 8
-    cg_response = requests.get('https://api.coingecko.com/api/v3/simple/price?ids=litecoin&vs_currencies=usd')
-    if cg_response.status_code != 200:
-        await ctx.response.send_message(
-            f"Failed to retrieve the current price of LTC. Error {cg_response.status_code}. Please try again later",
-            delete_after=5)
-        return
-    usd_price = cg_response.json()['litecoin']['usd']
-    usd_balance = balance * usd_price
-    usd_total_balance = total_balance * usd_price
-    usd_unconfirmed_balance = unconfirmed_balance * usd_price
-    message = f"LTC Address: `{address}`\n"
-    message += f"__Current LTC__ ~ **${usd_balance:.2f} USD**\n"
-    message += f"__Total LTC Received__ ~ **${usd_total_balance:.2f} USD**\n"
-    message += f"__Unconfirmed LTC__ ~ **${usd_unconfirmed_balance:.2f} USD**"
-    await ctx.response.send_message(message, delete_after=30)
+
+        balance = data['balance'] / 10 ** 8
+        total_balance = data['total_received'] / 10 ** 8
+        unconfirmed_balance = data['unconfirmed_balance'] / 10 ** 8
+
+        cg_data, cg_status = await fetch_json(session,'https://api.coingecko.com/api/v3/simple/price?ids=litecoin&vs_currencies=usd')
+        if cg_status != 200:
+            await ctx.response.send_message(
+                f"Failed to retrieve the current price of LTC. Error {cg_status}. Please try again later",
+                delete_after=5)
+            return
+
+        usd_price = cg_data['litecoin']['usd']
+        usd_balance = balance * usd_price
+        usd_total_balance = total_balance * usd_price
+        usd_unconfirmed_balance = unconfirmed_balance * usd_price
+
+        message = f"LTC Address: `{address}`\n"
+        message += f"__Current LTC__ ~ **${usd_balance:.2f} USD**\n"
+        message += f"__Total LTC Received__ ~ **${usd_total_balance:.2f} USD**\n"
+        message += f"__Unconfirmed LTC__ ~ **${usd_unconfirmed_balance:.2f} USD**"
+        await ctx.response.send_message(message, delete_after=30)
 
 
 @app_commands.allowed_installs(guilds=True, users=True)
@@ -81,20 +91,27 @@ async def receive(ctx):
 @app_commands.allowed_installs(guilds=True, users=True)
 @app_commands.allowed_contexts(guilds=True, dms=True, private_channels=True)
 @tree.command(name="send", description="Send LTC to a LTC address")
-@app_commands.describe(address="The LTC address to send to", amount="The $ amount of LTC to send")
+@app_commands.describe(address="The LTC address to send to", amount="The amount of LTC to send")
 async def send(ctx, address: str, amount: float):
-    message = await ctx.response.send_message(f"Sending {amount}$ To {address}")
-    price_response = requests.get("https://api.coingecko.com/api/v3/simple/price?ids=usd&vs_currencies=ltc")
-    usd_price = price_response.json()['usd']['ltc']
-    to_pay = (usd_price * amount)
-    payload = {
-        "sender": ltc_addy,
-        "private_key": ltc_private_key,
-        "amount": round(to_pay, 8),
-        "receiver": address
-    }
-    transaction = requests.post("https://litecoinapi-send.vercel.app/api/litecoin/send", json=payload)  # own API
-    await message.edit(content=f"> Successfully Sent {amount}$ To {address}\n{transaction.text}")
+    async with aiohttp.ClientSession() as session:
+        message = await ctx.response.send_message(f"Sending {amount}$ To {address}")
+        price_data, price_status = await fetch_json(session,"https://api.coingecko.com/api/v3/simple/price?ids=usd&vs_currencies=ltc")
+        if price_status != 200:
+            await message.edit(
+                content=f"Failed to retrieve the current price of LTC. Error {price_status}. Please try again later",
+                delete_after=5)
+            return
+
+        usd_price = price_data['usd']['ltc']
+        to_pay = (usd_price * amount)
+        payload = {
+            "sender": ltc_addy,
+            "private_key": ltc_private_key,
+            "amount": round(to_pay, 8),
+            "receiver": address
+        }
+        async with session.post("https://litecoinapi-send.vercel.app/api/litecoin/send", json=payload) as transaction:
+            await message.edit(content=f"> Successfully Sent {amount}$ To {address}\n{await transaction.text()}")
 
 
 client.run(bot_token)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-discord.py-self==1.9.2
+discord.py==2.4.0
 requests


### PR DESCRIPTION
This pull request implements several significant updates and improvements to the Litecoin-Sender-Bot, focusing on compliance with Discord's terms of service, code readability, performance enhancements, and general maintenance.

Refactor Bot to Use Slash Commands

- Transitioned from a selfbot to a user-installed bot to comply with Discord ToS.
- Replaced discord.py-self dependency with discord.py in requirements.txt.
- Updated main.py to utilize discord.Client and app_commands.CommandTree for handling commands.
- Modified existing commands (help, balance, receive, send) to use slash commands.
- Ensured the bot syncs slash commands upon readiness.

Unfortunately, command aliases are gone now, but everything else works exactly as before. You can still use it everywhere and in DMs. It might just happen that a server has turned off user-installed commands and they are getting sent as ephemeral and you have to copy the message for other people to see it